### PR TITLE
Add eslint-plugin-immer-reducer information to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Read an introductory [blog post here](https://medium.com/@esamatti/type-safe-boi
 
     npm install immer-reducer
 
+You can also install [eslint-plugin-immer-reducer](https://github.com/skoshy/eslint-plugin-immer-reducer) to help you avoid errors when writing your reducer.
+
 ## 💪 Motivation
 
 Turn this 💩 💩 💩
@@ -277,6 +279,8 @@ const actions = {
 }
 ```
 
+It is also recommended to install the ESLint plugin in the "Install" section
+to alert you if you accidentally encounter this issue.
 
 ## 📚 Examples
 


### PR DESCRIPTION
I've made an [ESLint plugin](https://github.com/skoshy/eslint-plugin-immer-reducer) to help avoid the issue of creating immer-reducer class methods with default or optional params.

Added links and information related to this in the README.